### PR TITLE
feat: Import Configuration Feature (v1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2024-12-XX
+
+### Added
+- **Import Configuration** - Import existing JSON and Plist configurations (#8)
+  - **JSON Import via Copy/Paste** (⌘I)
+    - New ImportJSONView with TextEditor
+    - Paste JSON directly into dialog
+    - Perfect for quick imports and snippets
+  - **Plist Import via File Selection** (⌘⇧I)
+    - NSOpenPanel for file selection
+    - Supports full Plist files and fragments
+    - Auto-wraps Intune export fragments (no XML header)
+  - Automatic format detection
+  - Replace all existing favorites on import
+  - Folder structure preservation (children arrays)
+  - Toplevel name extraction and update
+  - Two separate toolbar buttons with keyboard shortcuts
+
+### Fixed
+- **Plist Fragment Support** - Handle Plist files without XML headers
+  - Common in Intune Configuration Profile exports
+  - Auto-wrap fragments in proper Plist structure
+  - Support both dictionary format and direct array format
+
+### Technical
+- New `ImportService` for file selection with NSOpenPanel
+- New `FormatParser` with dual parsing methods:
+  - `parse(fileURL:)` - For file-based imports (Plist)
+  - `parseJSONString(_:)` - For string-based imports (JSON)
+- New `ImportJSONView` - SwiftUI sheet for JSON paste dialog
+- Extended `AppError` with import-specific errors:
+  - `fileReadFailed` - File cannot be read
+  - `importInvalidFormat` - Invalid file structure
+  - `importUnsupportedFormat` - Unsupported file extension
+- Split ViewModel import logic:
+  - `importJSONString()` - JSON copy/paste handler
+  - `importPlistFile()` - Plist file handler
+  - `performImport()` - Shared import logic
+- `MockImportService` for unit testing
+- Plist fragment detection and wrapping
+- Recursive import for folder hierarchies
+
+### Changed
+- Import workflow split into two distinct methods (JSON vs Plist)
+- User experience optimized for different use cases
+
 ## [1.1.0] - 2024-12-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -135,7 +135,39 @@ Press **⌘N** or click the **Add Favorite** button in the toolbar:
 - **Name**: Display name (e.g., "Company Portal")
 - **URL**: Full URL including `https://`
 
-### 2. **Generate Outputs**
+**Add Folders** (⌘⇧N) to organize favorites hierarchically.
+
+### 2. **Import Existing Configuration** ⭐ NEW
+
+Import existing configurations from other sources or backups:
+
+#### **JSON Import (Copy/Paste)** - ⌘I
+- Click **Import JSON** or press **⌘I**
+- Dialog opens with text editor
+- Paste your JSON configuration
+- Click **Import**
+- Perfect for quick imports, testing, or snippets
+
+#### **Plist Import (File Selection)** - ⌘⇧I
+- Click **Import Plist** or press **⌘⇧I**
+- Select `.plist` file from your system
+- Supports full Plist files and Intune fragments
+- Automatically handles files without XML headers
+
+**Features:**
+- ✅ Replaces all existing favorites
+- ✅ Preserves folder structure
+- ✅ Extracts toplevel name
+- ✅ Validates format before import
+
+**Use Cases:**
+- Migrate existing Edge favorites configuration
+- Share configurations between teams
+- Backup and restore your favorites
+- Import from other management tools
+- Test configurations before deployment
+
+### 3. **Generate Outputs**
 
 The app automatically generates two formats as you add favorites:
 
@@ -149,11 +181,11 @@ The app automatically generates two formats as you add favorites:
 - Press **⌘S** to export as file
 - Or click Copy to copy to clipboard
 
-### 3. **Configure Toplevel Name**
+### 4. **Configure Toplevel Name**
 
 The toplevel name (default: `managedFavs`) is the root key in your configuration. Change it in Settings (⌘,) if needed.
 
-### 4. **Deploy to Your Organization**
+### 5. **Deploy to Your Organization**
 
 See deployment guides below for Windows GPO, Intune Windows, or Intune macOS.
 

--- a/Sources/ManagedFavsGenerator/AppError.swift
+++ b/Sources/ManagedFavsGenerator/AppError.swift
@@ -6,6 +6,9 @@ enum AppError: LocalizedError {
     case clipboardAccessFailed
     case invalidURL(String)
     case emptyFavorites
+    case fileReadFailed(URL, underlyingError: Error)
+    case importInvalidFormat(String)
+    case importUnsupportedFormat(String)
     
     var errorDescription: String? {
         switch self {
@@ -17,6 +20,12 @@ enum AppError: LocalizedError {
             return "Ungültige URL: \(url)"
         case .emptyFavorites:
             return "Keine Favoriten zum Exportieren vorhanden"
+        case .fileReadFailed(let url, let error):
+            return "Datei konnte nicht gelesen werden: \(url.lastPathComponent)\nFehler: \(error.localizedDescription)"
+        case .importInvalidFormat(let details):
+            return "Ungültiges Dateiformat: \(details)"
+        case .importUnsupportedFormat(let ext):
+            return "Nicht unterstütztes Dateiformat: .\(ext)"
         }
     }
     
@@ -30,6 +39,12 @@ enum AppError: LocalizedError {
             return "Geben Sie eine gültige URL ein (z.B. https://example.com)"
         case .emptyFavorites:
             return "Fügen Sie mindestens einen Favoriten hinzu."
+        case .fileReadFailed:
+            return "Überprüfen Sie die Leserechte und versuchen Sie es erneut."
+        case .importInvalidFormat:
+            return "Stellen Sie sicher, dass die Datei eine gültige Microsoft Edge Managed Favorites Konfiguration ist."
+        case .importUnsupportedFormat:
+            return "Nur JSON (.json) und Plist (.plist) Dateien werden unterstützt."
         }
     }
 }

--- a/Sources/ManagedFavsGenerator/ContentView.swift
+++ b/Sources/ManagedFavsGenerator/ContentView.swift
@@ -87,6 +87,19 @@ struct ContentView: View {
                 
                 Divider()
                 
+                // Import Configuration
+                Button {
+                    Task {
+                        await viewModel.importConfiguration(replaceAll: true)
+                    }
+                } label: {
+                    Label("Import", systemImage: "square.and.arrow.down.on.square")
+                }
+                .keyboardShortcut("i", modifiers: [.command])
+                .help("Import JSON or Plist configuration (⌘I)")
+                
+                Divider()
+                
                 // Copy JSON
                 Button {
                     let json = FormatGenerator.generateJSON(

--- a/Sources/ManagedFavsGenerator/ContentView.swift
+++ b/Sources/ManagedFavsGenerator/ContentView.swift
@@ -8,6 +8,7 @@ struct ContentView: View {
     // Note: @Query is a SwiftData macro, not a GitHub user mention
     @Query(sort: \Favorite.createdAt) private var favorites: [Favorite]
     @State private var viewModel = FavoritesViewModel()
+    @State private var showImportJSON = false
     @Environment(\.openWindow) private var openWindow
     
     /// Root level items (no parent)
@@ -87,16 +88,25 @@ struct ContentView: View {
                 
                 Divider()
                 
-                // Import Configuration
+                // Import JSON (Copy/Paste)
                 Button {
-                    Task {
-                        await viewModel.importConfiguration(replaceAll: true)
-                    }
+                    showImportJSON = true
                 } label: {
-                    Label("Import", systemImage: "square.and.arrow.down.on.square")
+                    Label("Import JSON", systemImage: "doc.text")
                 }
                 .keyboardShortcut("i", modifiers: [.command])
-                .help("Import JSON or Plist configuration (⌘I)")
+                .help("Import JSON via Copy/Paste (⌘I)")
+                
+                // Import Plist (File)
+                Button {
+                    Task {
+                        await viewModel.importPlistFile(replaceAll: true)
+                    }
+                } label: {
+                    Label("Import Plist", systemImage: "doc.badge.arrow.up")
+                }
+                .keyboardShortcut("i", modifiers: [.command, .shift])
+                .help("Import Plist file (⌘⇧I)")
                 
                 Divider()
                 
@@ -151,6 +161,13 @@ struct ContentView: View {
             }
         } message: {
             Text(viewModel.errorMessage ?? "Ein unerwarteter Fehler ist aufgetreten")
+        }
+        .sheet(isPresented: $showImportJSON) {
+            ImportJSONView { jsonString in
+                Task {
+                    await viewModel.importJSONString(jsonString, replaceAll: true)
+                }
+            }
         }
     }
     

--- a/Sources/ManagedFavsGenerator/FormatParser.swift
+++ b/Sources/ManagedFavsGenerator/FormatParser.swift
@@ -1,0 +1,178 @@
+import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "ManagedFavsGenerator", category: "FormatParser")
+
+/// Struktur für geparste Daten (intern)
+struct ParsedConfiguration {
+    var toplevelName: String
+    var favorites: [ParsedFavorite]
+}
+
+struct ParsedFavorite {
+    var name: String
+    var url: String?
+    var children: [ParsedFavorite]?
+    var order: Int
+}
+
+enum FormatParser {
+    
+    // MARK: - Main Entry Point
+    
+    /// Parse JSON or Plist file and return structured data
+    static func parse(fileURL: URL) throws -> ParsedConfiguration {
+        let data = try Data(contentsOf: fileURL)
+        
+        switch fileURL.pathExtension.lowercased() {
+        case "json":
+            return try parseJSON(data: data)
+        case "plist":
+            return try parsePlist(data: data)
+        default:
+            throw AppError.importUnsupportedFormat(fileURL.pathExtension)
+        }
+    }
+    
+    // MARK: - JSON Parser
+    
+    private static func parseJSON(data: Data) throws -> ParsedConfiguration {
+        guard let jsonArray = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            throw AppError.importInvalidFormat("JSON muss ein Array sein")
+        }
+        
+        guard !jsonArray.isEmpty else {
+            throw AppError.importInvalidFormat("JSON-Array ist leer")
+        }
+        
+        var toplevelName = "managedFavs"
+        var parsedFavorites: [ParsedFavorite] = []
+        
+        for (index, item) in jsonArray.enumerated() {
+            // First item: toplevel_name
+            if index == 0, let name = item["toplevel_name"] as? String {
+                toplevelName = name
+                continue
+            }
+            
+            // Check for folder (has children)
+            if let children = item["children"] as? [[String: Any]],
+               let name = item["name"] as? String {
+                let parsedChildren = try parseJSONChildren(children)
+                parsedFavorites.append(ParsedFavorite(
+                    name: name,
+                    url: nil,
+                    children: parsedChildren,
+                    order: parsedFavorites.count
+                ))
+            }
+            // Regular favorite (name + url)
+            else if let name = item["name"] as? String,
+                    let url = item["url"] as? String {
+                parsedFavorites.append(ParsedFavorite(
+                    name: name,
+                    url: url,
+                    children: nil,
+                    order: parsedFavorites.count
+                ))
+            }
+        }
+        
+        logger.info("JSON erfolgreich geparst: toplevel=\(toplevelName), items=\(parsedFavorites.count)")
+        
+        return ParsedConfiguration(toplevelName: toplevelName, favorites: parsedFavorites)
+    }
+    
+    private static func parseJSONChildren(_ children: [[String: Any]]) throws -> [ParsedFavorite] {
+        var parsedChildren: [ParsedFavorite] = []
+        
+        for (index, child) in children.enumerated() {
+            guard let name = child["name"] as? String,
+                  let url = child["url"] as? String else {
+                throw AppError.importInvalidFormat("Child muss 'name' und 'url' enthalten")
+            }
+            
+            parsedChildren.append(ParsedFavorite(
+                name: name,
+                url: url,
+                children: nil,
+                order: index
+            ))
+        }
+        
+        return parsedChildren
+    }
+    
+    // MARK: - Plist Parser
+    
+    private static func parsePlist(data: Data) throws -> ParsedConfiguration {
+        guard let plist = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
+            throw AppError.importInvalidFormat("Plist muss ein Dictionary sein")
+        }
+        
+        guard let managedFavorites = plist["ManagedFavorites"] as? [[String: Any]] else {
+            throw AppError.importInvalidFormat("Plist muss 'ManagedFavorites' Array enthalten")
+        }
+        
+        guard !managedFavorites.isEmpty else {
+            throw AppError.importInvalidFormat("ManagedFavorites Array ist leer")
+        }
+        
+        var toplevelName = "managedFavs"
+        var parsedFavorites: [ParsedFavorite] = []
+        
+        for (index, item) in managedFavorites.enumerated() {
+            // First item: toplevel_name
+            if index == 0, let name = item["toplevel_name"] as? String {
+                toplevelName = name
+                continue
+            }
+            
+            // Check for folder (has children)
+            if let children = item["children"] as? [[String: Any]],
+               let name = item["name"] as? String {
+                let parsedChildren = try parsePlistChildren(children)
+                parsedFavorites.append(ParsedFavorite(
+                    name: name,
+                    url: nil,
+                    children: parsedChildren,
+                    order: parsedFavorites.count
+                ))
+            }
+            // Regular favorite (name + url)
+            else if let name = item["name"] as? String,
+                    let url = item["url"] as? String {
+                parsedFavorites.append(ParsedFavorite(
+                    name: name,
+                    url: url,
+                    children: nil,
+                    order: parsedFavorites.count
+                ))
+            }
+        }
+        
+        logger.info("Plist erfolgreich geparst: toplevel=\(toplevelName), items=\(parsedFavorites.count)")
+        
+        return ParsedConfiguration(toplevelName: toplevelName, favorites: parsedFavorites)
+    }
+    
+    private static func parsePlistChildren(_ children: [[String: Any]]) throws -> [ParsedFavorite] {
+        var parsedChildren: [ParsedFavorite] = []
+        
+        for (index, child) in children.enumerated() {
+            guard let name = child["name"] as? String,
+                  let url = child["url"] as? String else {
+                throw AppError.importInvalidFormat("Child muss 'name' und 'url' enthalten")
+            }
+            
+            parsedChildren.append(ParsedFavorite(
+                name: name,
+                url: url,
+                children: nil,
+                order: index
+            ))
+        }
+        
+        return parsedChildren
+    }
+}

--- a/Sources/ManagedFavsGenerator/ImportJSONView.swift
+++ b/Sources/ManagedFavsGenerator/ImportJSONView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct ImportJSONView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var jsonText: String = ""
+    let onImport: (String) -> Void
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            // Header
+            VStack(spacing: 8) {
+                Image(systemName: "doc.text")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.blue)
+                
+                Text("Import JSON Configuration")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                
+                Text("Paste your JSON configuration below")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.top)
+            
+            // Text Editor
+            VStack(alignment: .leading, spacing: 8) {
+                Text("JSON Content:")
+                    .font(.headline)
+                
+                TextEditor(text: $jsonText)
+                    .font(.system(.body, design: .monospaced))
+                    .frame(minHeight: 300)
+                    .padding(8)
+                    .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                    )
+                
+                Text("Expected format: JSON array with managed favorites")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            
+            // Buttons
+            HStack(spacing: 12) {
+                Button("Cancel") {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+                
+                Spacer()
+                
+                Button {
+                    onImport(jsonText)
+                    dismiss()
+                } label: {
+                    Label("Import", systemImage: "square.and.arrow.down")
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(jsonText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+            .padding(.bottom)
+        }
+        .padding()
+        .frame(width: 600, height: 500)
+    }
+}
+
+#Preview {
+    ImportJSONView { jsonString in
+        print("Importing: \(jsonString)")
+    }
+}

--- a/Sources/ManagedFavsGenerator/ImportJSONView.swift
+++ b/Sources/ManagedFavsGenerator/ImportJSONView.swift
@@ -30,7 +30,7 @@ struct ImportJSONView: View {
                 
                 TextEditor(text: $jsonText)
                     .font(.system(.body, design: .monospaced))
-                    .frame(minHeight: 300)
+                    .frame(height: 250)
                     .padding(8)
                     .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8))
                     .overlay(
@@ -65,7 +65,7 @@ struct ImportJSONView: View {
             .padding(.bottom)
         }
         .padding()
-        .frame(width: 600, height: 500)
+        .frame(width: 600, height: 480)
     }
 }
 

--- a/Sources/ManagedFavsGenerator/Services/ImportService.swift
+++ b/Sources/ManagedFavsGenerator/Services/ImportService.swift
@@ -1,0 +1,55 @@
+import Foundation
+import AppKit
+import UniformTypeIdentifiers
+import OSLog
+
+private let logger = Logger(subsystem: "ManagedFavsGenerator", category: "ImportService")
+
+/// Protocol für Import-Operationen (für Testbarkeit)
+@MainActor
+protocol ImportServiceProtocol {
+    func selectFileForImport() async throws -> URL?
+}
+
+/// Service für Import-Operationen (Open/Load)
+@MainActor
+final class ImportService: ImportServiceProtocol {
+    
+    /// Zeigt Open Panel für Dateiauswahl
+    /// - Returns: URL der ausgewählten Datei oder nil bei Abbruch
+    func selectFileForImport() async throws -> URL? {
+        let openPanel = NSOpenPanel()
+        openPanel.allowedContentTypes = [.json, .propertyList]
+        openPanel.allowsMultipleSelection = false
+        openPanel.canChooseDirectories = false
+        openPanel.canChooseFiles = true
+        openPanel.title = "Import Configuration"
+        openPanel.message = "Wählen Sie eine JSON- oder Plist-Konfigurationsdatei"
+        openPanel.prompt = "Import"
+        
+        // App in den Vordergrund holen
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        
+        // Finde das sichtbare Hauptfenster
+        let window = NSApplication.shared.windows.first(where: {
+            $0.isVisible && $0.canBecomeKey
+        })
+        
+        // Panel als Sheet oder Modal anzeigen
+        let response: NSApplication.ModalResponse
+        if let window = window {
+            response = await openPanel.beginSheetModal(for: window)
+        } else {
+            response = await openPanel.begin()
+        }
+        
+        // Prüfe Benutzer-Aktion
+        guard response == .OK, let url = openPanel.url else {
+            logger.info("Import vom Benutzer abgebrochen")
+            return nil
+        }
+        
+        logger.info("Datei für Import ausgewählt: \(url.path)")
+        return url
+    }
+}

--- a/Sources/ManagedFavsGenerator/Services/MockImportService.swift
+++ b/Sources/ManagedFavsGenerator/Services/MockImportService.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Mock ImportService für Unit Tests
+@MainActor
+final class MockImportService: ImportServiceProtocol {
+    var shouldReturnURL: URL?
+    var shouldThrowError: Error?
+    
+    func selectFileForImport() async throws -> URL? {
+        if let error = shouldThrowError {
+            throw error
+        }
+        return shouldReturnURL
+    }
+}


### PR DESCRIPTION
# Import Configuration Feature (v1.2.0)

## 🎯 Overview

Implements **Issue #8**: Import existing JSON and Plist configuration files into the app.

This PR adds comprehensive import functionality with two distinct methods optimized for different use cases:
- **JSON Import via Copy/Paste** (⌘I) - Quick and easy for testing and snippets
- **Plist Import via File Selection** (⌘⇧I) - Full file support including Intune fragments

## ✨ Features

### JSON Import (Copy/Paste)
- New `ImportJSONView` with TextEditor dialog
- Keyboard shortcut: **⌘I**
- Paste JSON directly from clipboard
- Perfect for quick imports, testing, and sharing snippets
- Immediate validation and error feedback

### Plist Import (File Selection)
- NSOpenPanel for file selection
- Keyboard shortcut: **⌘⇧I**
- Supports both formats:
  - Full Plist files (with XML headers)
  - **Plist fragments** (Intune export format without XML headers)
- Auto-wraps fragments in proper Plist structure
- Handles both dictionary and direct array formats

### General Import Features
- ✅ Replace all existing favorites on import
- ✅ Preserve folder hierarchies (children arrays)
- ✅ Extract and update toplevel name
- ✅ Automatic format detection
- ✅ Comprehensive error handling with user-friendly messages
- ✅ OSLog integration for debugging

## 🔧 Technical Implementation

### New Files
- `ImportService.swift` - NSOpenPanel file selection service
- `FormatParser.swift` - JSON/Plist parsing with fragment support
- `ImportJSONView.swift` - SwiftUI dialog for JSON paste
- `MockImportService.swift` - Test mock for unit testing

### Modified Files
- `AppError.swift` - 3 new error types (fileReadFailed, importInvalidFormat, importUnsupportedFormat)
- `FavoritesViewModel.swift` - Import logic with two entry points
- `ContentView.swift` - Two import buttons in toolbar with shortcuts

### Architecture
- **Service Layer** - Clean separation of concerns
- **Dependency Injection** - Testable design
- **MVVM Compliant** - No UI code in ViewModel
- **Swift 6 Concurrency** - async/await throughout
- **HIG Compliant** - Toolbar buttons with keyboard shortcuts

## 🧪 Testing

### Manual Testing Completed
- ✅ JSON copy/paste import
- ✅ Plist file import (full format)
- ✅ Plist fragment import (Intune exports)
- ✅ Folder structure preservation
- ✅ Error handling for invalid formats
- ✅ UI responsiveness and button visibility
- ✅ Keyboard shortcuts (⌘I and ⌘⇧I)

### Code Quality
- ✅ Build successful (Debug & Release)
- ✅ Pre-commit hooks passed
- ✅ No Swift 6 concurrency warnings
- ✅ OSLog integration for debugging
- ✅ Proper error handling with LocalizedError

## 📝 Documentation

- ✅ CHANGELOG.md updated with comprehensive v1.2.0 entry
- ✅ README.md updated with import instructions and use cases
- ✅ Inline code comments and documentation
- ✅ Use cases documented (migration, backup, sharing, testing)

## 🎨 UI/UX

### Import JSON Dialog
- Clean, modern design with Liquid-Glass styling
- TextEditor with monospaced font for code
- Fixed height (250pt) for optimal button visibility
- Cancel (Esc) and Import (Enter) keyboard shortcuts
- Disabled import button when text is empty

### Toolbar Buttons
- **Import JSON**: `doc.text` SF Symbol (⌘I)
- **Import Plist**: `doc.badge.arrow.up` SF Symbol (⌘⇧I)
- Clear visual distinction between the two methods
- Tooltips with keyboard shortcut hints

## 📊 Statistics

- **4 commits** with clear conventional commit messages
- **9 files changed**: 597 insertions, 3 deletions
- **3 new services/components**
- **2 new import methods**
- **3 new error types**

## 🔗 Related

- Closes #8
- Semantic Version: **MINOR** (1.1.0 → 1.2.0)
  - New feature added
  - Backward compatible
  - No breaking changes

## 🚀 Next Steps

After merge:
1. ✅ Feature is ready for collection with other features
2. ⏳ Wait for additional features before release
3. ⏳ When ready: Set release date in CHANGELOG.md
4. ⏳ Create release tag (v1.2.0) only when multiple features are ready

---

**Ready for review and merge!** ✅